### PR TITLE
fixbug

### DIFF
--- a/static/static.go
+++ b/static/static.go
@@ -83,7 +83,6 @@ func Serve(prefix string, fs ServeFileSystem) gin.HandlerFunc {
 
 		if fs.Exists(prefix, c.Request.URL.Path) {
 			fileserver.ServeHTTP(c.Writer, c.Request)
-			c.Abort()
 		} else {
 			c.Next()
 		}


### PR DESCRIPTION
fix https://github.com/gin-gonic/contrib/issues/17

Reason:

1.  c.Abort does not contain the proper number of arguments.
2.  The file service has been able to output HTTP status.