### PR TITLE
Fix build failed case by Context Abort interface change

### DIFF
--- a/secure/secure.go
+++ b/secure/secure.go
@@ -168,7 +168,7 @@ func Secure(options Options) gin.HandlerFunc {
 		err := s.process(c.Writer, c.Request)
 		if err != nil {
 			if c.Writer.Written() {
-				c.Abort()
+				c.AbortWithStatus(c.Writer.Status())
 			} else {
 				c.Fail(http.StatusInternalServerError, err)
 			}

--- a/static/static.go
+++ b/static/static.go
@@ -83,7 +83,7 @@ func Serve(prefix string, fs ServeFileSystem) gin.HandlerFunc {
 
 		if fs.Exists(prefix, c.Request.URL.Path) {
 			fileserver.ServeHTTP(c.Writer, c.Request)
-			c.Abort()
+			c.AbortWithStatus(c.Writer.Status())
 		} else {
 			c.Next()
 		}


### PR DESCRIPTION
Replace  c.Abort() with c.AbortWithStatus() function in those files.
 secure/secure.go 
 static/static.go
