### PR TITLE
bug fix in cache middleware

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -147,7 +147,7 @@ func CachePage(store CacheStore, expire time.Duration, handle gin.HandlerFunc) g
 			c.Writer.WriteHeader(cache.status)
 			for k, vals := range cache.header {
 				for _, v := range vals {
-					c.Writer.Header().Add(k, v)
+					c.Writer.Header().Set(k, v)
 				}
 			}
 			c.Writer.Write(cache.data)

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -87,10 +87,12 @@ func (w *cachedWriter) Write(data []byte) (int, error) {
 	if err == nil {
 		//cache response
 		store := w.store
+		newData := make([]byte, len(data))
+		copy(newData, data)
 		val := responseCache{
 			w.status,
 			w.Header(),
-			data,
+			newData,
 		}
 		err = store.Set(w.key, val, w.expire)
 		if err != nil {

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -138,10 +138,11 @@ func CachePage(store CacheStore, expire time.Duration, handle gin.HandlerFunc) g
 		url := c.Request.URL
 		key := urlEscape(PageCachePrefix, url.RequestURI())
 		if err := store.Get(key, &cache); err != nil {
+			tempC := c.Copy()
 			// replace writer
-			writer := newCachedWriter(store, expire, c.Writer, key)
-			c.Writer = writer
-			handle(c)
+			writer := newCachedWriter(store, expire, tempC.Writer, key)
+			tempC.Writer = writer
+			handle(tempC)
 		} else {
 			c.Writer.WriteHeader(cache.status)
 			for k, vals := range cache.header {


### PR DESCRIPTION
fix several problems during cache when I use cache middleware:
- fix bug in cachedWriter.Write(data []byte); current version just assigns the slice of data []byte into responseCache.data, slicing doesn't copy the slice data []byte data, it creates a new slice value that points to the original array. That means the points/references stored in the cache. That's dangerous, the original array is modified, the value in cache also being changed. This will not bring troubles for c.String(), but it brings bad effect for c.JSON, which use encoder in encoder pool.
- in CachePage(), when the cache is not hit, http responseWriter in the original context would be replaced by cachedWriter, it's better to use cachedWriter in the copied context for temp usage. so the original context would not be affected.
- in CachePage(), when the cache is hit, the http header would be fetched from the cache. Use set not add method to avoid the duplicated keys in the http header.
