### PR TITLE
Fixes issue with jwt middleware.

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -1,7 +1,6 @@
 package jwt
 
 import (
-	"bytes"
 	jwt_lib "github.com/dgrijalva/jwt-go"
 	"github.com/gin-gonic/gin"
 )
@@ -9,8 +8,7 @@ import (
 func Auth(secret string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		_, err := jwt_lib.ParseFromRequest(c.Request, func(token *jwt_lib.Token) (interface{}, error) {
-			var b bytes.Buffer
-			b.Write([]byte(secret))
+			b := ([]byte(secret))
 			return b, nil
 		})
 


### PR DESCRIPTION
Hey there! Love this middleware. Awesome stuff. :grin: 

Just ran into a weird problem today trying to use it.

From the looks of it, [jwt-go](https://github.com/dgrijalva/jwt-go/blob/a3e2f13bb7a4cfef6824fab97be5a7df9b86eff2/hmac.go) requires keyFunc to produce a key as a ```byte[]```. The current implementation produces a ```bytes.Buffer```, and therefore fails the type check on [line 48](https://github.com/dgrijalva/jwt-go/blob/a3e2f13bb7a4cfef6824fab97be5a7df9b86eff2/hmac.go#L48) of ```hmac.go```:

> key is invalid or of invalid type

This fix simply alters keyFunc to return the ```secret``` param as ```byte[]```.