### PR TITLE
added ginrus logrus logger middleware

### DIFF
--- a/ginrus/Godeps/Godeps.json
+++ b/ginrus/Godeps/Godeps.json
@@ -1,0 +1,10 @@
+{
+	"ImportPath": "github.com/gin-gonic/contrib/ginrus",
+	"GoVersion": "go1.3",
+	"Deps": [
+		{
+			"ImportPath": "github.com/gin-gonic/gin",
+			"Rev": "ac0ad2fed865d40a0adc1ac3ccaadc3acff5db4b"
+		}
+	]
+}

--- a/ginrus/example/example.go
+++ b/ginrus/example/example.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/gin-gonic/contrib/ginrus"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.New()
+
+	// Add a ginrus middleware, which:
+	//   - Logs all requests, like a combined access and error log.
+	//   - Logs to stdout.
+	//   - RFC3339 with UTC time format.
+	r.Use(ginrus.Ginrus(logrus.StandardLogger(), time.RFC3339, true))
+
+	// Add similar middleware, but:
+	//   - Only logs requests with errors, like an error log.
+	//   - Logs to stderr instead of stdout.
+	//   - Local time zone instead of UTC.
+	logger := logrus.New()
+	logger.Level = logrus.ErrorLevel
+	logger.SetOutput(os.Stderr)
+	r.Use(ginrus.Ginrus(logger, time.RFC3339, false))
+
+	// Example ping request.
+	r.GET("/ping", func(c *gin.Context) {
+		c.String(200, "pong "+fmt.Sprint(time.Now().Unix()))
+	})
+
+	// Listen and Server in 0.0.0.0:8080
+	r.Run(":8080")
+}

--- a/ginrus/ginrus.go
+++ b/ginrus/ginrus.go
@@ -1,0 +1,52 @@
+// Package ginrus provides log handling using logrus package.
+//
+// Based on github.com/stephenmuss/ginerus but adds more options.
+package ginrus
+
+import (
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/gin-gonic/gin"
+)
+
+// Ginrus returns a gin.HandlerFunc (middleware) that logs requests using logrus.
+//
+// Requests with errors are logged using logrus.Error().
+// Requests without errors are logged using logrus.Info().
+//
+// It receives:
+//   1. A time package format string (e.g. time.RFC3339).
+//   2. A boolean stating whether to use UTC time zone or local.
+func Ginrus(logger *logrus.Logger, timeFormat string, utc bool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		if utc {
+			start = start.UTC()
+		}
+
+		c.Next()
+
+		end := time.Now()
+		if utc {
+			end = end.UTC()
+		}
+
+		entry := logger.WithFields(logrus.Fields{
+			"status":     c.Writer.Status(),
+			"method":     c.Request.Method,
+			"path":       c.Request.URL.Path,
+			"ip":         c.ClientIP(),
+			"latency":    end.Sub(start),
+			"user-agent": c.Request.UserAgent(),
+			"time":       end.Format(timeFormat),
+		})
+
+		if len(c.Errors) > 0 {
+			// Append error field if this is an erroneous request.
+			entry.Error(c.Errors.String())
+		} else {
+			entry.Info()
+		}
+	}
+}


### PR DESCRIPTION
- This middleware provides loggin via github.com/Sirupsen/logrus package.
- It is based on https://github.com/stephenmuss/ginerus
- But adds more options:
  - Logging only errors.
  - Errors are logged via `logrus.Error()` function instead of `.Info()`.
  - Control time format and whether to use UTC or not.