### PR TITLE
Force users to validate the alg to protect against jwt vulnerability.

### DIFF
--- a/jwt/example/example.go
+++ b/jwt/example/example.go
@@ -31,7 +31,7 @@ func main() {
 	})
 
 	private := r.Group("/api/private")
-	private.Use(jwt.Auth(mysupersecretpassword))
+	private.Use(jwt.Auth(mysupersecretpassword,"HS256"))
 
 	/*
 		Set this header in your request to get here.

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -1,13 +1,29 @@
 package jwt
 
 import (
+	"fmt"
+
 	jwt_lib "github.com/dgrijalva/jwt-go"
 	"github.com/gin-gonic/gin"
 )
 
-func Auth(secret string) gin.HandlerFunc {
+func Auth(secret string, alg string) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		_, err := jwt_lib.ParseFromRequest(c.Request, func(token *jwt_lib.Token) (interface{}, error) {
+		token, err := jwt_lib.ParseFromRequest(c.Request, func(token *jwt_lib.Token) (interface{}, error) {
+
+			switch alg {
+			case "HS256", "HS384", "HS512":
+				if _, ok := token.Method.(*jwt_lib.SigningMethodHMAC); !ok {
+					return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+				}
+			case "RSA256", "RSA384", "RSA512":
+				if _, ok := token.Method.(*jwt_lib.SigningMethodRSA); !ok {
+					return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+				}
+			default:
+				return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+			}
+
 			b := ([]byte(secret))
 			return b, nil
 		})
@@ -15,5 +31,9 @@ func Auth(secret string) gin.HandlerFunc {
 		if err != nil {
 			c.AbortWithError(401, err)
 		}
+		if !token.Valid {
+			c.Fail(401, errors.New("Invalid Token"))
+		}
 	}
 }
+

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -32,8 +32,7 @@ func Auth(secret string, alg string) gin.HandlerFunc {
 			c.AbortWithError(401, err)
 		}
 		if !token.Valid {
-			c.Fail(401, errors.New("Invalid Token"))
+			c.AbortWithError(401, fmt.Errorf("Invalid Token"))
 		}
 	}
 }
-

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -9,7 +9,7 @@ import (
 
 func Auth(secret string, alg string) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		token, err := jwt_lib.ParseFromRequest(c.Request, func(token *jwt_lib.Token) (interface{}, error) {
+		jwtoken, err := jwt_lib.ParseFromRequest(c.Request, func(token *jwt_lib.Token) (interface{}, error) {
 
 			switch alg {
 			case "HS256", "HS384", "HS512":
@@ -30,9 +30,12 @@ func Auth(secret string, alg string) gin.HandlerFunc {
 
 		if err != nil {
 			c.AbortWithError(401, err)
-		}
-		if !token.Valid {
+		} else if !jwtoken.Valid {
 			c.AbortWithError(401, fmt.Errorf("Invalid Token"))
 		}
+
+		//set it to context to use the info it contains in handlers
+		c.Set("jwt", jwtoken)
 	}
 }
+


### PR DESCRIPTION
Published on https://github.com/dgrijalva/jwt-go README:

NOTICE: A vulnerability in JWT was recently published. As this library doesn't force users to validate the alg is what they expected, it's possible your usage is effected. There will be an update soon to remedy this, and it will likey require backwards-incompatible changes to the API. In the short term, please make sure your implementation verifies the alg is what you expect.

So in the mean time I implemented this fix following their instructions. 

``` go
 // Don't forget to validate the alg is what you expect:
        if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
            return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
        }
```

Also added the fixes from #34 
