### PR TITLE
added StatsD middleware, for reporting metrics to a StatsD agent.

### DIFF
--- a/statsd/configured_client.go
+++ b/statsd/configured_client.go
@@ -1,0 +1,106 @@
+package statsd
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// configuredClient wraps a StatsD Client with configuration settings.
+type configuredClient struct {
+	Client Client
+
+	// On/off switch for each metric.
+	ResponseTimeEnabled,
+	ThroughputEnabled,
+	StatusCodeEnabled,
+	SuccessEnabled,
+	ErrorEnabled bool
+
+	// Bucket names for each metric.
+	ResponseTimeBucket,
+	ThroughputBucket,
+	StatusCodeBucket,
+	SuccessBucket,
+	ErrorBucket string
+}
+
+func newConfiguredClient(client Client) *configuredClient {
+	return &configuredClient{
+		Client: client,
+
+		ResponseTimeEnabled: DefaultResponseTimeEnabled,
+		ThroughputEnabled:   DefaultThroughputEnabled,
+		StatusCodeEnabled:   DefaultStatusCodeEnabled,
+		SuccessEnabled:      DefaultSuccessEnabled,
+		ErrorEnabled:        DefaultErrorEnabled,
+
+		ResponseTimeBucket: DefaultResponseTimeBucket,
+		ThroughputBucket:   DefaultThroughputBucket,
+		StatusCodeBucket:   DefaultStatusCodeBucket,
+		SuccessBucket:      DefaultSuccessBucket,
+		ErrorBucket:        DefaultErrorBucket,
+	}
+}
+
+// IncrThroughput increments the received requests bucket.
+func (c *configuredClient) IncrThroughput(handler string) {
+	if c.ThroughputEnabled {
+		c.Client.Incr(join(handler, c.ThroughputBucket), 1)
+	}
+}
+
+// IncrStatusCode increments the context's response status code bucket.
+func (c *configuredClient) IncrStatusCode(status int, handler string) {
+	if c.StatusCodeEnabled {
+		c.Client.Incr(join(handler, c.StatusCodeBucket, strconv.Itoa(status)), 1)
+	}
+}
+
+// IncrSuccess increments the success bucket
+// if no errors were attached to the context.
+func (c *configuredClient) IncrSuccess(errors []*gin.Error, handler string) {
+	if c.SuccessEnabled && len(errors) == 0 {
+		c.Client.Incr(join(handler, c.SuccessBucket), 1)
+	}
+}
+
+// IncrError increments the error bucket for each attached error.
+// If a gin.Error.Meta implements the Bucket interface,
+// its associated bucket will be incremented instead of the default error bucket.
+// See the Bucket interface for more info.
+//
+// NOTE that if at least one error was attached to the context,
+// calling IncrSucess does nothing.
+func (c *configuredClient) IncrError(errors []*gin.Error, handler string) {
+	if c.ErrorEnabled {
+		for _, err := range errors {
+			// If the gin.Error.Meta implements the Bucket interface,
+			// increment its specific bucket by its given increment amount.
+			// Otherwise, increment the default error bucket with the default amount.
+			b, ok := err.Meta.(Bucket)
+			if !ok {
+				c.Client.Incr(join(handler, c.ErrorBucket), 1)
+				continue
+			}
+			c.Client.Incr(join(handler, b.BucketName()), 1)
+		}
+	}
+}
+
+// Timing calculates time taken to process the request.
+func (c *configuredClient) Timing(start time.Time, handler string) {
+	if c.ResponseTimeEnabled {
+		c.Client.Timing(join(handler, c.ResponseTimeBucket),
+			// Convert to milliseconds.
+			time.Now().Sub(start).Nanoseconds()/time.Millisecond.Nanoseconds())
+	}
+}
+
+// join is a helper function that joins strings to a valid StatsD bucket name,
+// separated by a dot '.'.
+//
+// It's main use is to have cleaner code in this library.
+func join(strs ...string) string { return strings.Join(strs, ".") }

--- a/statsd/example/example.go
+++ b/statsd/example/example.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	middleware "github.com/gin-gonic/contrib/statsd"
+	"github.com/gin-gonic/gin"
+	"github.com/quipo/statsd"
+)
+
+func main() {
+	// Initialize a StatsD agent of your choice,
+	// which implements the Client interface.
+	client := statsd.NewStatsdClient("127.0.0.1", "my.app.")
+	bufferedClient := statsd.NewStatsdBuffer(5*time.Second, client)
+
+	r := gin.New()
+
+	// Add a StatsD middleware with a custom throughput bucket name.
+	// See the other option functions for additional settings.
+	r.Use(middleware.Statsd(bufferedClient,
+		middleware.SetThroughputBucket("request.received")))
+
+	// Example ping request.
+	r.GET("/ping", func(c *gin.Context) {
+		c.String(200, "pong "+fmt.Sprint(time.Now().Unix()))
+	})
+
+	// Listen and Server in 0.0.0.0:8080
+	r.Run(":8080")
+}

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -1,0 +1,72 @@
+// Here be option setting functions for the statsd middleware.
+
+package statsd
+
+const (
+	DefaultResponseTimeEnabled = true
+	DefaultThroughputEnabled   = true
+	DefaultStatusCodeEnabled   = true
+	DefaultSuccessEnabled      = true
+	DefaultErrorEnabled        = true
+
+	DefaultResponseTimeBucket = "request.response_time"
+	DefaultThroughputBucket   = "request.throughput"
+	DefaultStatusCodeBucket   = "request.status_code"
+	DefaultSuccessBucket      = "request.success"
+	DefaultErrorBucket        = "request.error.default"
+)
+
+// OptionFunc is a configuration function, used in Statsd().
+type OptionFunc func(*configuredClient)
+
+func SetResponseTime(enabled bool) OptionFunc {
+	return func(s *configuredClient) {
+		s.ResponseTimeEnabled = enabled
+	}
+}
+func SetThroughput(enabled bool) OptionFunc {
+	return func(s *configuredClient) {
+		s.ThroughputEnabled = enabled
+	}
+}
+func SetStatusCode(enabled bool) OptionFunc {
+	return func(s *configuredClient) {
+		s.StatusCodeEnabled = enabled
+	}
+}
+func SetSuccess(enabled bool) OptionFunc {
+	return func(s *configuredClient) {
+		s.SuccessEnabled = enabled
+	}
+}
+func SetError(enabled bool) OptionFunc {
+	return func(s *configuredClient) {
+		s.ErrorEnabled = enabled
+	}
+}
+
+func SetResponseTimeBucket(name string) OptionFunc {
+	return func(s *configuredClient) {
+		s.ResponseTimeBucket = name
+	}
+}
+func SetThroughputBucket(name string) OptionFunc {
+	return func(s *configuredClient) {
+		s.ThroughputBucket = name
+	}
+}
+func SetStatusCodeBucket(name string) OptionFunc {
+	return func(s *configuredClient) {
+		s.StatusCodeBucket = name
+	}
+}
+func SetSuccessBucket(name string) OptionFunc {
+	return func(s *configuredClient) {
+		s.SuccessBucket = name
+	}
+}
+func SetErrorBucket(name string) OptionFunc {
+	return func(s *configuredClient) {
+		s.ErrorBucket = name
+	}
+}

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -1,0 +1,70 @@
+// Package statsd provides reporting HTTP performance to a StatsD agent.
+package statsd
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// The Client interface is implemented by a StatsD client.
+// The middleware receives a Client object and uses it to report metrics.
+//
+// You can use any StatsD client you wish,
+// as long as it implements this interface.
+//
+// I wrote this middleware to be used with the most popular package:
+// github.com/quipo/statsd
+type Client interface {
+	Incr(stat string, count int64) error
+	Timing(stat string, delta int64) error
+}
+
+// The Bucket interface is implemented by gin.Error.Meta types
+// who wish their associated error to increment a different bucket
+// INSTEAD of the default error bucket.
+//
+// E.g. Consider two error types E and F.
+// E implements the Bucket interface while F does not.
+// Upon an E error, the E.BucketName() bucket will be incremented.
+// Upon an F error, the generic error bucket will be incremented.
+type Bucket interface {
+	BucketName() string // Bucket name to increment.
+}
+
+// Statsd returns a gin.HandleFunc (middleware) that sends metrics to the given StatsD Client.
+//
+// The following metrics are collected and reported to the given StatsD agent:
+//   1. Request throughput count.
+//   2. Response status code count.
+//   3. Response time.
+//   4. Successful response count.
+//      A response is considered "successful" if no errors were attached to its context.
+//   5. Context error count.
+//      If three errors were attached to the context, three increments will occur.
+//
+// Bucket names have a default value, which can be set by the option functions.
+//
+// Furthermore, if a gin.Error.Meta type implements the Bucket interface,
+// its associated bucket will be incremented INSTEAD of the default error bucket.
+// See the Bucket interface for more info.
+func Statsd(client Client, options ...OptionFunc) gin.HandlerFunc {
+	// Initialize and configure the client and set options if given.
+	cc := newConfiguredClient(client)
+	for _, option := range options {
+		option(cc)
+	}
+
+	return func(c *gin.Context) {
+		start := time.Now()
+
+		c.Next()
+
+		handler := c.HandlerName()
+		cc.IncrThroughput(handler)
+		cc.IncrStatusCode(c.Writer.Status(), handler)
+		cc.IncrSuccess(c.Errors, handler)
+		cc.IncrError(c.Errors, handler)
+		cc.Timing(start, handler)
+	}
+}


### PR DESCRIPTION
- currently supported metrics:
  - request throughput count
  - response time
  - status code count
  - successful requests count
  - erroneous requests count
    - can assign different buckets to error types.
- using functional options, for easier future additions.
  see the following article for more info:
  http://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
- accepts a statsd client interface instead of a specific package implementation.
  this practically means that any statsd client package can be used,
  as long as it supports Incr() and Timing().
  if not, the developer can wrap its client to comply with the interace.
  i wrote this middleware to be used with the most popular package:
  github.com/quipo/statsd
- configuration options:
  - per-metric bucket name
  - per-`gin.HandlerFunc` bucket name
  - per-error type bucket name
- fully documented
- includes example
