### PR TITLE
Adds link to headerauth middleware.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Each author is responsible of maintaining his own code, although if you submit a
 ## List of external middleware
 
 + [staticbin](https://github.com/olebedev/staticbin) - middleware/handler for serving static files from binary data
-+ [signedauth](https://github.com/ChristopherRabotin/gin-contrib-signedauth) - middleware for handling signed requests and authentication based on request headers.
++ [headerauth](https://github.com/ChristopherRabotin/gin-contrib-headerauth) - middleware for handling authentication based on request headers, with and without HMAC signatures.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Each author is responsible of maintaining his own code, although if you submit a
 ## List of external middleware
 
 + [staticbin](https://github.com/olebedev/staticbin) - middleware/handler for serving static files from binary data
++ [signedauth](https://github.com/ChristopherRabotin/gin-contrib-signedauth) - middleware for handling signed requests and authentication based on request headers.


### PR DESCRIPTION
Implemented #43 on a separate repo, forced by a two month awaiting code review of #44.

Although the build of _contrib_ fails, the _headerauth_ middleware has its own tests that pass: [![pass successfully](https://travis-ci.org/ChristopherRabotin/gin-contrib-headerauth.svg?branch=master)](https://travis-ci.org/ChristopherRabotin/gin-contrib-headerauth) [![Coverage Status](https://coveralls.io/repos/ChristopherRabotin/gin-contrib-headerauth/badge.svg?branch=master&service=github)](https://coveralls.io/github/ChristopherRabotin/gin-contrib-headerauth?branch=master).
