### PR TITLE
Fix handling of WriteString in gzip middleware

### DIFF
--- a/gzip/gzip.go
+++ b/gzip/gzip.go
@@ -42,6 +42,10 @@ type gzipWriter struct {
 	writer *gzip.Writer
 }
 
+func (g *gzipWriter) WriteString(s string) (n int, err error) {
+	return g.writer.Write([]byte(s))
+}
+
 func (g *gzipWriter) Write(data []byte) (int, error) {
 	return g.writer.Write(data)
 }


### PR DESCRIPTION
When using the gzip middleware, calls to WriteString were falling through to
using the embedded gin.ResponseWriter's WriteString.  This would sidestep
the gzip encoder and inject uncompressed data into the output.

This change makes the gzip middleware handle the call itself.

Running the 'TestGzip' test in the existing test suite demonstrates the issue.