### PR TITLE
add contrib/connection/close.go

### DIFF
--- a/connection/close.go
+++ b/connection/close.go
@@ -1,0 +1,33 @@
+package connection
+
+import (
+	"log"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CloseAfterPrefix will ensure that the connection is explicitly closed by the
+// server if the route matches urlPrefix.
+func CloseAfterPrefix(urlPrefix string) gin.HandlerFunc {
+	if urlPrefix == "" {
+		log.Println("setting closeConnectionOn prefix to \"/\"")
+		urlPrefix = "/"
+	}
+
+	return func(c *gin.Context) {
+		if strings.HasPrefix(c.Request.URL.Path, urlPrefix) {
+			c.Request.Header.Set("Connection", "close")
+		}
+		c.Next()
+	}
+}
+
+// CloseAfterAll will close all http requests after the route has finished
+// serving
+func CloseAfterAll() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Request.Header.Set("Connection", "close")
+		c.Next()
+	}
+}


### PR DESCRIPTION
Provide two functions to force the connection to be closed (HTTP/1.1
uses persistent connections by default) based on prefix or blanket
across all routes.

Refs:

http://craigwickesser.com/2015/01/golang-http-to-many-open-files/
http://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html

Tested and verified with curl.
