### PR TITLE
Ginrus takes an entry instead of a logger

### DIFF
--- a/ginrus/ginrus.go
+++ b/ginrus/ginrus.go
@@ -18,7 +18,7 @@ import (
 // It receives:
 //   1. A time package format string (e.g. time.RFC3339).
 //   2. A boolean stating whether to use UTC time zone or local.
-func Ginrus(logger *logrus.Logger, timeFormat string, utc bool) gin.HandlerFunc {
+func Ginrus(logger *logrus.Entry, timeFormat string, utc bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
 		// some evil middlewares modify this values


### PR DESCRIPTION
This way you can decorate your logs with anything you might need instead of only the fields inside the middleware
