### PR TITLE
Prevent hijack Write

### DIFF
--- a/gzip/gzip.go
+++ b/gzip/gzip.go
@@ -18,21 +18,27 @@ const (
 
 func Gzip(level int) gin.HandlerFunc {
 	return func(c *gin.Context) {
+
 		if !shouldCompress(c.Request) {
 			return
 		}
+
 		gz, err := gzip.NewWriterLevel(c.Writer, level)
+
 		if err != nil {
 			return
 		}
 
 		c.Header("Content-Encoding", "gzip")
 		c.Header("Vary", "Accept-Encoding")
+
 		c.Writer = &gzipWriter{c.Writer, gz}
+
 		defer func() {
 			c.Header("Content-Length", "")
 			gz.Close()
 		}()
+
 		c.Next()
 	}
 }
@@ -50,8 +56,15 @@ func shouldCompress(req *http.Request) bool {
 	if !strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
 		return false
 	}
+
+	if strings.Contains(req.Header.Get("Connection"), "Upgrade") {
+		return false
+	}
+
 	extension := filepath.Ext(req.URL.Path)
-	if len(extension) < 4 { // fast path
+
+	// fast path
+	if len(extension) < 4 {
 		return true
 	}
 


### PR DESCRIPTION
Make sure the connection was not upgraded to prevent hijacked connection writes (response.Write).

I'm not 100% this is the best solution but it has been working.