### PR TITLE
Fix broken sessions example package names

### DIFF
--- a/sessions/examples/cookie/example_cookie.go
+++ b/sessions/examples/cookie/example_cookie.go
@@ -1,4 +1,4 @@
-package maincookie
+package main
 
 import (
 	"github.com/gin-gonic/contrib/sessions"

--- a/sessions/examples/redis/example_redis.go
+++ b/sessions/examples/redis/example_redis.go
@@ -1,4 +1,4 @@
-package mainredis
+package main
 
 import (
 	"github.com/gin-gonic/contrib/sessions"


### PR DESCRIPTION
Mixing (arbitrary) package names breaks various tooling, move the sessions example files to separate directories and rename packages to `main`