### PR TITLE
Set decoded token claims into context

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -7,10 +7,12 @@ import (
 
 func Auth(secret string) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		_, err := jwt_lib.ParseFromRequest(c.Request, func(token *jwt_lib.Token) (interface{}, error) {
+		token, err := jwt_lib.ParseFromRequest(c.Request, func(token *jwt_lib.Token) (interface{}, error) {
 			b := ([]byte(secret))
 			return b, nil
 		})
+
+		c.Set("token-claims", token.Claims)
 
 		if err != nil {
 			c.AbortWithError(401, err)

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -12,6 +12,7 @@ func Auth(secret string) gin.HandlerFunc {
 			return b, nil
 		})
 
+		// Put claims into context so that handlers can use info such as userId
 		c.Set("token-claims", token.Claims)
 
 		if err != nil {


### PR DESCRIPTION
You can encode Claims into JWT token so that you can access user id and other data you deem important. However, there was no way to get these, so I added them to the Context object upon token decode.
