### PR TITLE
add a way to get session id

### DIFF
--- a/sessions/redis.go
+++ b/sessions/redis.go
@@ -2,6 +2,7 @@ package sessions
 
 import (
 	"github.com/boj/redistore"
+	"github.com/garyburd/redigo/redis"
 	"github.com/gorilla/sessions"
 )
 
@@ -24,6 +25,14 @@ type RedisStore interface {
 // if set, must be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256 modes.
 func NewRedisStore(size int, network, address, password string, keyPairs ...[]byte) (RedisStore, error) {
 	store, err := redistore.NewRediStore(size, network, address, password, keyPairs...)
+	if err != nil {
+		return nil, err
+	}
+	return &redisStore{store}, nil
+}
+
+func NewRediStoreWithPool(pool *redis.Pool, keyPairs ...[]byte) (RedisStore, error) {
+	store, err := redistore.NewRediStoreWithPool(pool, keyPairs...)
 	if err != nil {
 		return nil, err
 	}

--- a/sessions/sessions.go
+++ b/sessions/sessions.go
@@ -35,6 +35,7 @@ type Options struct {
 // Wraps thinly gorilla-session methods.
 // Session stores the values and optional configuration for a session.
 type Session interface {
+	ID() string
 	// Get returns the session value associated to the given key.
 	Get(key interface{}) interface{}
 	// Set sets the session value associated to the given key.
@@ -73,6 +74,10 @@ type session struct {
 	session *sessions.Session
 	written bool
 	writer  http.ResponseWriter
+}
+
+func (s *session) ID() string {
+	return s.session.ID
 }
 
 func (s *session) Get(key interface{}) interface{} {


### PR DESCRIPTION
Session ID is a common information, it deserves a method for developers to get it. On current version of `sessions`, gorilla's session is encapsulated thus I couldn't find a way to get `session id`
