### PR TITLE
Add jwt middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,5 @@ Each author is responsible of maintaining his own code, although if you submit a
 + [gin-csrf](https://github.com/utrack/gin-csrf) - CSRF protection
 + [gin-health](https://github.com/utrack/gin-health) - middleware that simplifies stat reporting via [gocraft/health](https://github.com/gocraft/health)
 + [gin-merry](https://github.com/utrack/gin-merry) - middleware for pretty-printing [merry](https://github.com/ansel1/merry) errors with context
-+ [gin-revision](https://github.com/appleboy/gin-revision-middleware/) - Revision middleware for Gin framework
++ [gin-revision](https://github.com/appleboy/gin-revision-middleware) - Revision middleware for Gin framework
++ [gin-jwt](https://github.com/appleboy/gin-jwt) - JWT Middleware for Gin Framework


### PR DESCRIPTION
This is a middleware for Gin.

It uses jwt-go to provide a jwt authentication middleware. It provides additional handler functions to provide the login api that will generate the token and an additional refresh handler that can be used to refresh tokens.

@javierprovecho Do you want to remove jwt folder? If so, I can handle it.

closed #85 #84 #50

https://github.com/appleboy/gin-jwt