### PR TITLE
Add ekyoung/gin-nice-recovery to the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ Each author is responsible of maintaining his own code, although if you submit a
 + [gin-jwt](https://github.com/appleboy/gin-jwt) - JWT Middleware for Gin Framework
 + [gin-sessions](https://github.com/kimiazhu/ginweb-contrib/tree/master/sessions) - session middleware based on mongodb and mysql
 + [gin-location](https://github.com/drone/gin-location) - middleware for exposing the server's hostname and scheme
++ [gin-nice-recovery](https://github.com/ekyoung/gin-nice-recovery) - panic recovery middleware that let's you build a nicer user experience


### PR DESCRIPTION
A substitute for the `gin.Recovery()` middleware that passes control back to the application to render a nice error page, custom error JSON, etc.