### PR TITLE
Fix cors header writing

### DIFF
--- a/cors/cors.go
+++ b/cors/cors.go
@@ -124,7 +124,7 @@ func New(config Config) gin.HandlerFunc {
 }
 
 func handlePreflight(c *gin.Context, s *settings) bool {
-	c.AbortWithStatus(200)
+	defer c.AbortWithStatus(200)
 	if !s.validateMethod(c.Request.Header.Get("Access-Control-Request-Method")) {
 		return false
 	}


### PR DESCRIPTION
Fix cors header writing broken by gin [4c4444b](https://github.com/gin-gonic/gin/commit/4c4444b16033c7b000492f57119901cba9870b5c) commit.
