### PR TITLE
Add missing user identifier part

### DIFF
--- a/commonlog/commonlog.go
+++ b/commonlog/commonlog.go
@@ -26,8 +26,6 @@ func NewWithWriter(out io.Writer) gin.HandlerFunc {
 		},
 	}
 	return func(c *gin.Context) {
-		path := c.Request.URL.Path
-
 		// Process request
 		c.Next()
 
@@ -35,12 +33,12 @@ func NewWithWriter(out io.Writer) gin.HandlerFunc {
 		w := pool.Get().(*bytes.Buffer)
 		w.Reset()
 		w.WriteString(c.ClientIP())
-		w.WriteString(" ")
+		w.WriteString(" - - ")
 		w.WriteString(time.Now().Format("[02/Jan/2006:15:04:05 -0700] "))
 		w.WriteString("\"")
 		w.WriteString(c.Request.Method)
 		w.WriteString(" ")
-		w.WriteString(path)
+		w.WriteString(c.Request.URL.Path)
 		w.WriteString(" ")
 		w.WriteString(c.Request.Proto)
 		w.WriteString("\" ")


### PR DESCRIPTION
The user identifier parts were missing. Usually these are just dashes if you don't have a userid to add, e.g.: http://stackoverflow.com/questions/12544510/parsing-apache-log-files