### PR TITLE
CORS: Fixing transmission of headers + added HTTP method and headers checks

### DIFF
--- a/cors/cors.go
+++ b/cors/cors.go
@@ -127,10 +127,8 @@ func New(config Config) gin.HandlerFunc {
 		}
 		c.Header("Access-Control-Allow-Origin", origin)
 
-		if ( options ) { // We don't want to let gin switch to the next layer (does it actually matter ?)
+		if ( options ) { // We don't want to let gin switch to the next layer
 			c.AbortWithStatus(http.StatusOK)
-		} else {
-			c.Next()
 		}
 	}
 }


### PR DESCRIPTION
- The call "c.AbortWithStatus(http.StatusOK)" in handlePreflight was preventing from sending headers afterwards.
- Added some HTTP method and HTTP headers checks