### PR TITLE
Updated sentry middleware to import v1 version of gin

### DIFF
--- a/sentry/recovery.go
+++ b/sentry/recovery.go
@@ -7,7 +7,7 @@ import (
 	"runtime/debug"
 
 	"github.com/getsentry/raven-go"
-	"github.com/gin-gonic/gin"
+	"gopkg.in/gin-gonic/gin.v1"
 )
 
 func Recovery(client *raven.Client, onlyCrashes bool) gin.HandlerFunc {


### PR DESCRIPTION
The current version breaks as it doesn't point to the v1 locked version from gopkg.