### PR TITLE
Fix logrus vendor rename (case-sensitive issue)

### DIFF
--- a/ginrus/example/example.go
+++ b/ginrus/example/example.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/gin-gonic/contrib/ginrus"
 	"github.com/gin-gonic/gin"
 )

--- a/ginrus/ginrus.go
+++ b/ginrus/ginrus.go
@@ -6,7 +6,7 @@ package ginrus
 import (
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 )
 


### PR DESCRIPTION
This fixes the error `case-insensitive import collision: "github.com/<redacted>/vendor/github.com/Sirupsen/logrus" and "github.com/<redacted>/vendor/github.com/sirupsen/logrus"`

See https://github.com/sirupsen/logrus#case-sensitivity