### PR TITLE
Fix import case

### DIFF
--- a/ginrus/example/example.go
+++ b/ginrus/example/example.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/contrib/ginrus"
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {

--- a/ginrus/ginrus.go
+++ b/ginrus/ginrus.go
@@ -6,8 +6,8 @@ package ginrus
 import (
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 )
 
 // Ginrus returns a gin.HandlerFunc (middleware) that logs requests using logrus.


### PR DESCRIPTION
> Seeing weird case-sensitive problems? It's in the past been possible to import Logrus as both upper- and lower-case. Due to the Go package environment, this caused issues in the community and we needed a standard. Some environments experienced problems with the upper-case variant, so the lower-case was decided. Everything using logrus will need to use the lower-case: github.com/sirupsen/logrus. Any package that isn't, should be changed.

From https://github.com/sirupsen/logrus/blob/master/README.md