### PR TITLE
Added gin-helmet to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ Each author is responsible of maintaining his own code, although if you submit a
 + [gin-oauth2](https://github.com/zalando/gin-oauth2) - for working with OAuth2
 + [static](https://github.com/hyperboloide/static) An alternative static assets handler for the gin framework.
 + [xss-mw](https://github.com/dvwright/xss-mw) - XssMw is a middleware designed to "auto remove XSS" from user submitted input
++ [gin-helmet](https://github.com/danielkov/gin-helmet) - Collection of simple security middleware.


### PR DESCRIPTION
Hello.
I've created a library of useful security-related middleware for gin. It's inspired by `helmet` for `express` and has a similar API. It may be useful for others who want a drop-in security solution for basic use-cases.