### PR TITLE
add gin-go-metrics to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,5 @@ Each author is responsible of maintaining his own code, although if you submit a
 + [ginception](https://github.com/kubastick/ginception) - Nice looking exception page
 + [gin-inspector](https://github.com/fatihkahveci/gin-inspector) - Gin middleware for investigating http request.
 + [gin-dump](https://github.com/tpkeeper/gin-dump) - Gin middleware/handler to dump header/body of request and response. Very helpful for debugging your applications.
++ [go-gin-prometheus](https://github.com/zsais/go-gin-prometheus) - Gin Prometheus metrics exporter 
 + [gin-go-metrics](https://github.com/bmc-toolbox/gin-go-metrics) - Gin middleware to gather and store metrics using [rcrowley/go-metrics](https://github.com/rcrowley/go-metrics)

--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ Each author is responsible of maintaining his own code, although if you submit a
 + [ginception](https://github.com/kubastick/ginception) - Nice looking exception page
 + [gin-inspector](https://github.com/fatihkahveci/gin-inspector) - Gin middleware for investigating http request.
 + [gin-dump](https://github.com/tpkeeper/gin-dump) - Gin middleware/handler to dump header/body of request and response. Very helpful for debugging your applications.
++ [gin-go-metrics](https://github.com/bmc-toolbox/gin-go-metrics) - Gin middleware to gather and store metrics using [rcrowley/go-metrics](https://github.com/rcrowley/go-metrics)


### PR DESCRIPTION
Thanks for gathering all this useful information!
Recently I've discovered that there is no [go-metrics](https://github.com/rcrowley/go-metrics) stats middleware and wrote one myself using a similar thing ([go-gin-prometheus](https://github.com/banzaicloud/go-gin-prometheus) by @banzaicloud) as a starting point.
I'll be glad if mentioned middlewares will be added to this list.