### PR TITLE
Update: add ginprom project

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,6 @@ Each author is responsible of maintaining his own code, although if you submit a
 + [ginception](https://github.com/kubastick/ginception) - Nice looking exception page
 + [gin-inspector](https://github.com/fatihkahveci/gin-inspector) - Gin middleware for investigating http request.
 + [gin-dump](https://github.com/tpkeeper/gin-dump) - Gin middleware/handler to dump header/body of request and response. Very helpful for debugging your applications.
-+ [go-gin-prometheus](https://github.com/zsais/go-gin-prometheus) - Gin Prometheus metrics exporter 
++ [go-gin-prometheus](https://github.com/zsais/go-gin-prometheus) - Gin Prometheus metrics exporter
++ [ginprom](https://github.com/chenjiandongx/ginprom) - Prometheus metrics exporter for Gin
 + [gin-go-metrics](https://github.com/bmc-toolbox/gin-go-metrics) - Gin middleware to gather and store metrics using [rcrowley/go-metrics](https://github.com/rcrowley/go-metrics)


### PR DESCRIPTION
Thanks all you guys! Gin is a great web-framework and we have used it in production. 

[ginprom](https://github.com/chenjiandongx/ginprom) is another Prometheus metrics exporter for Gin And it provides a useful Grafana dashboard.

![](https://user-images.githubusercontent.com/19553554/63159844-f01e2400-c04e-11e9-8b49-69ff3c3159cb.png)

![](https://user-images.githubusercontent.com/19553554/63159842-eeecf700-c04e-11e9-8f6f-ad0d9dec89ad.png)
