### PR TITLE
allow use of RSA keys in JWT

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -8,12 +8,15 @@ import (
 
 func Auth(secret interface{}) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		_, err := request.ParseFromRequest(c.Request, request.OAuth2Extractor, func(token *jwt_lib.Token) (interface{}, error) {
+		token, err := request.ParseFromRequest(c.Request, request.OAuth2Extractor, func(token *jwt_lib.Token) (interface{}, error) {
 			return secret, nil
 		})
 
 		if err != nil {
 			c.AbortWithError(401, err)
+		}
+		if c, ok := token.Claims.(MapClaims); ok {
+			c.Set("JWT", c)
 		}
 	}
 }

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -15,8 +15,8 @@ func Auth(secret interface{}) gin.HandlerFunc {
 		if err != nil {
 			c.AbortWithError(401, err)
 		}
-		if c, ok := token.Claims.(jwt_lib.MapClaims); ok {
-			c.Set("JWT", c)
+		if claims, ok := token.Claims.(jwt_lib.MapClaims); ok {
+			c.Set("JWT", claims)
 		}
 	}
 }

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -6,11 +6,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func Auth(secret string) gin.HandlerFunc {
+func Auth(secret interface{}) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		_, err := request.ParseFromRequest(c.Request, request.OAuth2Extractor, func(token *jwt_lib.Token) (interface{}, error) {
-			b := ([]byte(secret))
-			return b, nil
+			return secret, nil
 		})
 
 		if err != nil {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -15,7 +15,7 @@ func Auth(secret interface{}) gin.HandlerFunc {
 		if err != nil {
 			c.AbortWithError(401, err)
 		}
-		if c, ok := token.Claims.(MapClaims); ok {
+		if c, ok := token.Claims.(jwt_lib.MapClaims); ok {
 			c.Set("JWT", c)
 		}
 	}


### PR DESCRIPTION
Change type of secret to interface{} in order to allow jwt.Auth accept rsa.PublicKey for RSA256 token signing.