### PR TITLE
Prometheus No compression

### DIFF
--- a/gzip/gzip.go
+++ b/gzip/gzip.go
@@ -54,6 +54,12 @@ func shouldCompress(req *http.Request) bool {
 	if !strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
 		return false
 	}
+	
+	// Prometheus reg /metrics No compression
+	if req.RequestURI == "/metrics" {
+		return false
+	}
+	
 	extension := filepath.Ext(req.URL.Path)
 	if len(extension) < 4 { // fast path
 		return true


### PR DESCRIPTION
起因于在暴露 Prometheus 采集端点时错误响应的问题。

经追查，因 `prometheus/client_golang` 在 `ServeHTTP()` 中会检查响应头(`Accept-Encoding`) 实现压缩，这样在启用`gzip`中间件后，会出现重复压缩。

现象: Prometheus 无法正常采集暴露信息，浏览器访问会直接下载。

以下三种方案: 
1. 添加 `gzip` 白名单(此 PR 变更)
2. 将 `/metrics` 注册在 `gzip` 前面，避免压缩
3. 禁用 `prometheus/client_golang` 压缩(见下)

#### 禁用 prometheus/client_golang` 压缩

```go
// Prometheus 监控访问点
func Prometheus(c *gin.Context) {
	// register promhttp.HandlerOpts DisableCompression
	promhttp.InstrumentMetricHandler(prometheus.DefaultRegisterer, promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
		DisableCompression: true,
	})).ServeHTTP(c.Writer, c.Request)
	//promhttp.Handler().ServeHTTP(c.Writer, c.Request)
}
```

> 我是更推荐使用 `方案三` 但提交一个 PR 以作记录，方便遇到同样问题的朋友能够搜索到。