### PR TITLE
feat: Added nocache middleware

### DIFF
--- a/nocache/README.md
+++ b/nocache/README.md
@@ -1,0 +1,23 @@
+# NoCache
+
+NoCache is a simple piece of middleware that sets a number of HTTP headers to prevent a router (or subrouter) from being cached by an upstream proxy and/or client.
+
+## Usage
+```go
+package main
+
+import (
+    "github.com/gin-gonic/gin"
+    "github.com/gin-contrib/nocache"
+)
+
+func main() {
+    g := gin.New()
+    g.Use(nocache.NoCache())
+    g.GET("/", func(c *gin.Context) {
+        c.JSON(200, gin.H{
+            "status": "It will not be cached",
+        })
+    })
+}
+```

--- a/nocache/README.md
+++ b/nocache/README.md
@@ -16,7 +16,7 @@ func main() {
     g.Use(nocache.NoCache())
     g.GET("/", func(c *gin.Context) {
         c.JSON(200, gin.H{
-            "status": "It will not be cached",
+            "result": "It will not be cached",
         })
     })
 }

--- a/nocache/nocache.go
+++ b/nocache/nocache.go
@@ -1,8 +1,10 @@
 package nocache
 
-import "time"
+import (
+	"time"
 
-import "github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin"
+)
 
 // Unix epoch time
 var epoch = time.Unix(0, 0).Format(time.RFC1123)

--- a/nocache/nocache.go
+++ b/nocache/nocache.go
@@ -1,0 +1,51 @@
+package nocache
+
+import "time"
+
+import "github.com/gin-gonic/gin"
+
+// Unix epoch time
+var epoch = time.Unix(0, 0).Format(time.RFC1123)
+
+// Taken from https://github.com/mytrile/nocache
+var noCacheHeaders = map[string]string{
+	"Expires":         epoch,
+	"Cache-Control":   "no-cache, no-store, no-transform, must-revalidate, private, max-age=0",
+	"Pragma":          "no-cache",
+	"X-Accel-Expires": "0",
+}
+
+var etagHeaders = []string{
+	"ETag",
+	"If-Modified-Since",
+	"If-Match",
+	"If-None-Match",
+	"If-Range",
+	"If-Unmodified-Since",
+}
+
+// NoCache is a simple piece of middleware that sets a number of HTTP headers to prevent
+// a router (or subrouter) from being cached by an upstream proxy and/or client.
+//
+// As per http://wiki.nginx.org/HttpProxyModule - NoCache sets:
+//      Expires: Thu, 01 Jan 1970 00:00:00 UTC
+//      Cache-Control: no-cache, private, max-age=0
+//      X-Accel-Expires: 0
+//      Pragma: no-cache (for HTTP/1.0 proxies/clients)
+func NoCache() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Delete any ETag headers that may have been set
+		for _, v := range etagHeaders {
+			if c.Request.Header.Get(v) != "" {
+				c.Request.Header.Del(v)
+			}
+		}
+
+		// Set our NoCache headers
+		for k, v := range noCacheHeaders {
+			c.Writer.Header().Set(k, v)
+		}
+
+		c.Next()
+	}
+}

--- a/nocache/nocache_test.go
+++ b/nocache/nocache_test.go
@@ -14,7 +14,9 @@ func TestNoCache(t *testing.T) {
 	g := gin.New()
 	g.Use(NoCache())
 	g.GET("/test", func(c *gin.Context) {
-		c.JSON(200, "test")
+		c.JSON(200, gin.H{
+			"test": "test",
+		})
 	})
 	g.ServeHTTP(w, r)
 

--- a/nocache/nocache_test.go
+++ b/nocache/nocache_test.go
@@ -1,0 +1,26 @@
+package nocache
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNoCache(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/test", nil)
+	g := gin.New()
+	g.Use(NoCache())
+	g.GET("/test", func(c *gin.Context) {
+		c.JSON(200, "test")
+	})
+	g.ServeHTTP(w, r)
+
+	for k, v := range noCacheHeaders {
+		t.Run(k, func(t *testing.T) {
+			require.Equal(t, w.Header().Get(k), v)
+		})
+	}
+}


### PR DESCRIPTION
NoCache is a simple piece of middleware that sets a number of HTTP headers to prevent a router (or subrouter) from being cached by an upstream proxy and/or client.