### PR TITLE
Add Sqreen for Go middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Each author is responsible for maintaining their own code, although if you submi
   
 ## List of external middleware
 
++ [Sqreen](https://github.com/sqreen/go-agent/tree/master/sdk/middleware/sqgin#readme) - Application Security Monitoring and Protection
 + [RestGate](https://github.com/pjebs/restgate) - Secure authentication for REST API endpoints
 + [staticbin](https://github.com/olebedev/staticbin) - middleware/handler for serving static files from binary data
 + [gin-cors](https://github.com/gin-contrib/cors) - Official CORS gin's middleware


### PR DESCRIPTION
Add Sqreen's application monitoring and protection middleware for Gin.